### PR TITLE
better session ids & redundant sha1 removal 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -18,6 +18,9 @@ collective.captcha changes
   view, allowing restricted code to verify submitted captchas.
   [mj]
 
+- Better session id generation & redundant sha1 removal.
+  [serhat]
+
 1.6 (2011-05-29)
 ----------------
 

--- a/collective/captcha/browser/captcha.py
+++ b/collective/captcha/browser/captcha.py
@@ -1,12 +1,11 @@
 # Zope Captcha generation
 import os.path
-import random
+from random import getrandbits
+from time import time
 try:
     from hashlib import sha1
 except ImportError: # Python < 2.5
     from sha import new as sha1
-import sys
-import time
 
 from skimpyGimpy import skimpyAPI
 
@@ -29,14 +28,19 @@ _package_home = package_home(globals())
 WAVSOUNDS = os.path.join(_package_home, 'waveIndex.zip')
 VERAMONO = os.path.join(_package_home, 'arevmoit.bdf')
 
-_TEST_TIME = None
+PERIOD = 240 # captcha will be valid for PERIOD to 2*PERIOD seconds
 
 class Captcha(BrowserView):
     implements(ICaptchaView)
-    
+
     _session_id = None
+    SECRET = ''
     __name__ = 'captcha'
-    
+
+    def __init__(self, context, request):
+        super(Captcha, self).__init__(context, request)
+        self.SECRET = getUtility(IKeyManager).secret()
+
     def _setcookie(self, id):
         """Set the session cookie"""
         resp = self.request.response
@@ -49,7 +53,7 @@ class Captcha(BrowserView):
     def _generate_session(self):
         """Create a new session id"""
         if self._session_id is None:
-            id = sha1(str(random.randrange(sys.maxint))).hexdigest()
+            id = hex(getrandbits(64))[2:-1]
             self._session_id = id
             self._setcookie(id)
 
@@ -64,55 +68,53 @@ class Captcha(BrowserView):
                 self._setcookie(self._session_id)
             # Put the cookie value into the request for immediate consumption
             self.request.cookies[COOKIE_ID] = self._session_id
-    
+
+    def _generate(self, nowish=0):
+        if nowish == 0:
+            nowish = int(time() / PERIOD)
+
+        seed = sha1(self.SECRET+ self.request[COOKIE_ID]+ hex(nowish)).digest()
+        word = ''
+        for i in xrange(WORDLENGTH):
+            index = ord(seed[i]) % len(CHARS)
+            word += CHARS[index]
+
+        return word
+
     def _generate_words(self):
         """Create words for the current session
-        
-        We generate one for the current 5 minutes, plus one for the previous
-        5. This way captcha sessions have a livespan of 10 minutes at most.
-        
+
+        We generate one for the current 4 minutes, plus one for the previous.
+        This way captcha sessions have a livespan of 8 minutes at most.
         """
-        session = self.request[COOKIE_ID]
-        nowish = int((_TEST_TIME or time.time()) / 300)
-        secret = getUtility(IKeyManager).secret()
-        seeds = [sha1(secret + session + str(nowish)).digest(),
-                 sha1(secret + session + str(nowish - 1)).digest()]
-        
-        words = []
-        for seed in seeds:
-            word = []
-            for i in range(WORDLENGTH):
-                index = ord(seed[i]) % len(CHARS)
-                word.append(CHARS[index])
-            words.append(''.join(word))
-        return words
-    
+        nowish = int(time() / PERIOD)
+
+        return (self._generate(nowish), self._generate(nowish-1))
+
     def _url(self, type):
         return '%s/@@%s/%s' % (
             aq_inner(self.context).absolute_url(), self.__name__, type)
-    
+
     def image_tag(self):
         self._generate_session()
         return '<img src="%s" />' % (self._url('image'),)
-    
+
     def audio_url(self):
         self._generate_session()
         return self._url('audio')
-        
+
     def verify(self, input):
-        result = False
         try:
-            for word in self._generate_words():
-                result = result or input.upper() == word.upper()
+            words = self._generate_words()
             # Delete the session key, we are done with this captcha
             self.request.response.expireCookie(COOKIE_ID, path='/')
         except KeyError:
-            pass # No cookie
-        
-        return result
-        
+            return False
+        input = input.upper()
+        return input == words[0] or input == words[1]
+
     # Binary data subpages
-    
+
     def _setheaders(self, type):
         resp = self.request.response
         resp.setHeader('content-type', type)
@@ -120,16 +122,16 @@ class Captcha(BrowserView):
         resp.setHeader('cache-control', 'no-cache, no-store')
         resp.setHeader('pragma', 'no-cache')
         resp.setHeader('expires', 'now')
-        
+
     def image(self):
         """Generate a captcha image"""
         self._verify_session()
         self._setheaders('image/png')
-        return skimpyAPI.Png(self._generate_words()[0],
+        return skimpyAPI.Png(self._generate(), speckle=1.5,
                              fontpath=VERAMONO).data()
-    
+
     def audio(self):
         """Generate a captcha audio file"""
         self._verify_session()
         self._setheaders('audio/wav')
-        return skimpyAPI.Wave(self._generate_words()[0], WAVSOUNDS).data()
+        return skimpyAPI.Wave(self._generate(), WAVSOUNDS).data()

--- a/collective/captcha/browser/captcha.txt
+++ b/collective/captcha/browser/captcha.txt
@@ -35,13 +35,13 @@ The view doesn't actually give us the word, but we can replay an existing
 session for the test:
 
   >>> request = DummyRequest()
-  >>> session_id = '6552fec8867ee2a85a44784dda007e49efcf50ef'
+  >>> session_id = 'a3c189690379c1fe'
   >>> request.cookies[COOKIE_ID] = session_id
   >>> view = Captcha(context, request)
 
 The verify method, then, tells you if the user entered the correct word:
 
-  >>> view.verify('DLXV4XV')
+  >>> view.verify('FDX7BU3')
   True
   
 Note that the view immediately invalidates the cookie by expiring it:
@@ -51,14 +51,14 @@ Note that the view immediately invalidates the cookie by expiring it:
   
 The verify method works case-insensitively:
 
-  >>> view.verify('dlxv4xv')
+  >>> view.verify('fdx7BU3')
   True
   
-The words are valid for a 10 minute period, with a new word for the session
-every 5 minutes. Thus, the word for the previous 5 minute period should still
+The words are valid for an 8 minute period, with a new word for the session
+every 4 minutes. Thus, the word for the previous 4 minute period should still
 be valid:
 
-  >>> view.verify('EXCXY74')
+  >>> view.verify('7N6NWYP')
   True
 
 Verification will fail for both incorrect input and a missing cookie:
@@ -68,7 +68,7 @@ Verification will fail for both incorrect input and a missing cookie:
 
   >>> del request.other[COOKIE_ID]
   >>> del request.cookies[COOKIE_ID]
-  >>> view.verify('DLXV4XV')
+  >>> view.verify('FDX7BU3')
   False
 
 To facilitate displaying a new captcha when verification fails or validation 

--- a/collective/captcha/browser/tests.py
+++ b/collective/captcha/browser/tests.py
@@ -1,16 +1,16 @@
 import unittest
 import doctest
+from os import remove
+from os.path import dirname
 from zope.component import provideUtility
 from zope.testing import cleanup
 from plone.keyring.interfaces import IKeyManager
 
-# Set the secret and test time to constants to keep the tests workable
-import collective.captcha.browser.captcha as captcha
-captcha._TEST_TIME = 1500
-
 # Use a real Request and Response; there are too many subtleties
 from ZPublisher.Request import Request
 from ZPublisher.Response import Response
+
+basedir = dirname(__file__)
 
 class DummyRequest(Request):
     def __init__(self):
@@ -18,7 +18,7 @@ class DummyRequest(Request):
                'SERVER_PORT': '80',
                'REQUEST_METHOD': 'GET'}
         Request.__init__(self, None, env, Response())
-        
+
 class DummyContext(object):
     def absolute_url(self):
         return 'dummyurl'
@@ -28,10 +28,18 @@ class DummyKeyManager(object):
         return 'tests-only-stable-value'
 
 def captchaSetUp(test):
+    # cheat time. dont try it in real life
+    with open(basedir+ '/time.py', 'w') as f:
+        f.write("def time():\n  return 1500\n")
     provideUtility(DummyKeyManager(), IKeyManager)
 
 def tearDown(test):
     cleanup.cleanUp()
+    for s in ('', 'o', 'c'):
+        try:
+            remove(basedir+ '/time.py'+ s) # purge generated files
+        except OSError:
+            pass
 
 def test_suite():
     return unittest.TestSuite((

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,10 @@ setup(name='collective.captcha',
           'setuptools',
           'skimpyGimpy',
           'plone.keyring > 1.0',
-      ]
+      ],
+      extras_require={'test': ['zope.testing', 'zope.component', 'Zope2', 'plone.keyring']},
+      entry_points="""
+      [z3c.autoinclude.plugin]
+      target = plone
+      """,
       )


### PR DESCRIPTION
- better session id generation
- eliminate redundant sha1 calls
- make base period 4 minutes (more than enough)
- change tests accordingly
- add extra_require and entry_points to setup.py
